### PR TITLE
Fix entity filtering on deciles chart

### DIFF
--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -86,7 +86,6 @@ def update_deciles(page_state):
     if not deciles_traces:
         return html.Div()
     months = deciles_traces[0].x
-    ymax = trace_df.calc_value.max() + trace_df.calc_value_error.max()
     if (
         col_name in ["practice_id", "ccg_id"]
         and "all" not in entity_ids_for_practice_filter

--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -76,8 +76,6 @@ def update_deciles(page_state):
         numerators=numerators,
         denominators=denominators,
         result_filter=result_filter,
-        practice_filter_entity=practice_filter_entity,
-        entity_ids_for_practice_filter=entity_ids_for_practice_filter,
         by=col_name,
         hide_entities_with_sparse_data=page_state.get("sparse_data_toggle"),
     )
@@ -91,7 +89,7 @@ def update_deciles(page_state):
         and "all" not in entity_ids_for_practice_filter
     ):
         entity_ids = get_sorted_group_keys(
-            trace_df[trace_df.ccg_id.isin(entity_ids_for_practice_filter)], col_name
+            trace_df[trace_df[practice_filter_entity].isin(entity_ids_for_practice_filter)], col_name
         )
     else:
         entity_ids = get_sorted_group_keys(trace_df, col_name)


### PR DESCRIPTION
The filtering needs to be done *after* the deciles are calculated. If
you want to view, say, a single practice chart you still need to
calculate the deciles across all other practices.