### PR TITLE
Use "practice_id" consistently instead of "practice"

### DIFF
--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -67,10 +67,7 @@ def update_deciles(page_state):
         "entity_ids_for_practice_filter", []
     )
 
-    if groupby == "practice":
-        col_name = "practice_id"
-    else:
-        col_name = groupby
+    col_name = groupby
 
     trace_df = get_count_data(
         numerators=numerators,

--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -71,10 +71,7 @@ def update_heatmap(page_state):
     entity_ids_for_practice_filter = page_state.get(
         "entity_ids_for_practice_filter", []
     )
-    if groupby == "practice":
-        col_name = "practice_id"
-    else:
-        col_name = groupby
+    col_name = groupby
     trace_df = get_count_data(
         numerators=numerators,
         denominators=denominators,

--- a/apps/test_counts.py
+++ b/apps/test_counts.py
@@ -30,10 +30,7 @@ def update_counts(page_state):
         "entity_ids_for_practice_filter", []
     )
 
-    if groupby == "practice":
-        col_name = "practice_id"
-    else:
-        col_name = groupby
+    col_name = groupby
     df = get_count_data(
         numerators=numerators,
         denominators=denominators,

--- a/layout.py
+++ b/layout.py
@@ -133,7 +133,7 @@ def layout(tests_df, ccgs_list, measures):
             dcc.Dropdown(
                 id="groupby-dropdown",
                 options=[
-                    {"value": "practice", "label": "Practice"},
+                    {"value": "practice_id", "label": "Practice"},
                     {"value": "test_code", "label": "Test code"},
                     {"value": "ccg_id", "label": "CCG"},
                     {"value": "result_category", "label": "Result"},

--- a/stateful_routing.py
+++ b/stateful_routing.py
@@ -131,7 +131,7 @@ def update_state_from_inputs(
     if "denominators" not in page_state:
         update_state(page_state, denominators=["per1000"])
     if "groupby" not in page_state:
-        update_state(page_state, groupby="practice")
+        update_state(page_state, groupby="practice_id")
     if "practice_filter_entity" not in page_state:
         update_state(page_state, practice_filter_entity="ccg_id")
     if "entity_ids_for_practice_filter" not in page_state:

--- a/urls.py
+++ b/urls.py
@@ -20,7 +20,7 @@ class AppConverter(BaseConverter):
 
 
 class EntityConverter(BaseConverter):
-    regex = r"(?:ccg_id|practice|lab|test_code|result_category)"
+    regex = r"(?:ccg_id|practice_id|lab|test_code|result_category)"
 
 
 url_map = Map(


### PR DESCRIPTION
This makes practice filtering work (see #5) if you manually edit the URL e.g 
http://dash.openpathology.net/data/counts/by/practice_id/showing/practice_id/33/numerators/K/denominators/per1000/filter/all

But I think we need a UI for this util we can close the associated ticket.