### PR TITLE
Use text labels for result categories on heatmap

### DIFF
--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -102,8 +102,7 @@ def update_heatmap(page_state, current_qs, current_fig):
         index=col_name, columns="month", values="label"
     ).reindex(vals_by_entity.index)
 
-    entity_type = humanise_entity_type(col_name)
-    entities = [f"{entity_type} {x}" for x in vals_by_entity.index]
+    entities = [humanise_entity_name(col_name, x) for x in vals_by_entity.index]
     # sort with hottest at top
     trace = go.Heatmap(
         z=vals_by_entity,
@@ -159,6 +158,7 @@ def update_heatmap(page_state, current_qs, current_fig):
             xaxis={"fixedrange": True},
             yaxis={
                 "fixedrange": True,
+                "automargin": True,
                 "tickmode": "array",
                 "tickvals": entities,
                 "ticktext": entities,
@@ -167,11 +167,13 @@ def update_heatmap(page_state, current_qs, current_fig):
     }
 
 
-def humanise_entity_type(column_name):
+def humanise_entity_name(column_name, value):
     if column_name == "ccg_id":
-        return "CCG"
+        return f"CCG {value}"
     if column_name == "practice_id":
-        return "Practice"
+        return f"Practice {value}"
     if column_name == "test_code":
-        return "Test"
-    return column_name
+        return f"Test {value}"
+    if column_name == "result_category":
+        return settings.ERROR_CODES_SHORT[value]
+    return f"{column_name} {value}"

--- a/settings.py
+++ b/settings.py
@@ -57,3 +57,16 @@ ERROR_CODES = {
     6: "with no ref range calculated for children",
     7: "with no ref range calculated - invalid ref range",
 }
+
+
+ERROR_CODES_SHORT = {
+    0: "Within range",
+    -1: "Under range",
+    1: "Over range",
+    2: "No ref range",
+    3: "Non-numeric result",
+    4: "Invalid sex",
+    5: "Impossible direction",  # What does this mean?
+    6: "Child (no ref range)",
+    7: "Invalid ref range",
+}


### PR DESCRIPTION
This involves writing shorter versions of the descriptions and enabling
`automargin` so the labels don't get cut off.

The short labels could maybe be improved. In particular, "impossible
direction" as I'm not quite clear what that means.

Fixes #32