### PR TITLE
Explain what result categories mean

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,5 +56,10 @@ def measures():
     return render_template("measures.html")
 
 
+@server.route("/faq")
+def faq():
+    return render_template("faq.html")
+
+
 cache = Cache()
 cache.init_app(app.server, config=settings.CACHE_CONFIG)

--- a/apps/base.py
+++ b/apps/base.py
@@ -85,5 +85,5 @@ def humanise_entity_name(column_name, value):
     if column_name == "test_code":
         return get_test_code_to_name_map()[value]
     if column_name == "result_category":
-        return settings.ERROR_CODES_SHORT[value]
+        return settings.ERROR_CODES[value]
     return f"{column_name} {value}"

--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -188,3 +188,17 @@ def update_heatmap(page_state, current_qs, current_fig):
             },
         ),
     }
+
+
+@app.callback(
+    Output("result-category-hint", "style"), [Input("page-state", "children")]
+)
+def toggle_result_category_hint(page_state):
+    page_state = get_state(page_state)
+    visible = False
+    if page_state.get("groupby") == "result_category":
+        visible = True
+    result_filter = page_state.get("result_filter")
+    if result_filter and result_filter != "all":
+        visible = True
+    return {"display": "" if visible else "none"}

--- a/layout.py
+++ b/layout.py
@@ -140,10 +140,26 @@ def layout(tests_df, ccgs_list):
             dbc.Tab(label="Practice-level data table", tab_id="datatable"),
         ],
     )
+    result_category_hint = html.P(
+        [
+            "* for more detail on reference ranges and result codes see the ",
+            html.A("FAQ", href="/faq#result-categories"),
+        ],
+        id="result-category-hint",
+        className="text-muted",
+        style={"display": "none"},
+    )
     form = dbc.Container(
         dbc.Row(
             [
-                dbc.Col([numerators_form, denominators_form, groupby_form]),
+                dbc.Col(
+                    [
+                        numerators_form,
+                        denominators_form,
+                        groupby_form,
+                        result_category_hint,
+                    ]
+                ),
                 dbc.Col([ccg_filter_form, tweak_form]),
             ]
         )

--- a/settings.py
+++ b/settings.py
@@ -52,9 +52,9 @@ ERROR_CODES = {
     1: "Over range",
     2: "No ref range",
     3: "Non-numeric result",
-    4: "Invalid sex",
-    5: "Impossible direction",  # What does this mean?
-    6: "Child (no ref range)",
+    4: "Unknown sex",
+    5: "Insufficient data",
+    6: "Underage for ref range",
     7: "Invalid ref range",
 }
 

--- a/settings.py
+++ b/settings.py
@@ -47,19 +47,6 @@ LINE_COLOUR_CYCLE = [
 
 
 ERROR_CODES = {
-    0: "within range",
-    -1: "under range",
-    1: "over range",
-    2: "with no ref range available",
-    3: "with non-numeric result",
-    4: "with invalid sex",
-    5: "with no ref range calculated - impossible direction",
-    6: "with no ref range calculated for children",
-    7: "with no ref range calculated - invalid ref range",
-}
-
-
-ERROR_CODES_SHORT = {
     0: "Within range",
     -1: "Under range",
     1: "Over range",

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,9 @@
       <li class="nav-item">
         <a class="nav-link" href="/measures">Measures</a>
       </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/faq">FAQ</a>
+      </li>
     </ul>
   </div>
 </nav>

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -12,43 +12,67 @@
 
   <h2 id="reference-ranges">What are reference ranges?</h2>
   <p>
+    For many sorts of test the results will be compared with a reference range,
+    which is the range of results considered "normal". Where possible we check
+    each test result against its reference range and record whether it was
+    within, over or under this range.  For more detail on the many problems and
+    complexities involved in reference ranges see our blog posts <a
+      href="https://openpathology.net/blog/issues-with-reference-ranges-part-1">here</a>,
+    <a
+      href="https://openpathology.net/blog/issues-with-reference-ranges-part-2">here</a>
+    and <a
+      href="https://openpathology.net/blog/issues-with-reference-ranges-part-3">here</a>.
   </p>
 
 
   <h2 id="result-categories">What do the result categories and error codes mean?</h2>
 
-  <p>
-  </p>
-
   <dl>
     <dt>Within range / Under range / Over range</dt>
     <dd>
-      We could determine the appropriate reference range for this result and have coded how the resut compared to this
-      reference range.
+      We determined the appropriate reference range for this result and have
+      coded how the result compared to this reference range.
     </dd>
 
     <dt>No ref range</dt>
     <dd>
+      There was no reference range available for this result. This might be
+      because a reference range simply doesn't make sense for this kind of
+      test. Or it could be that we haven't been able to obtain a reference
+      range for this test from the particular lab involved. (Note that
+      different labs can have different reference ranges for a given test.)
     </dd>
 
     <dt>Invalid ref range</dt>
     <dd>
+      We have been supplied with a reference range, but we were unable to
+      interpret it correctly.
     </dd>
 
     <dt>Non-numeric result</dt>
     <dd>
+      The result was some sort of error code, rather than a number.
     </dd>
 
     <dt>Unknown sex</dt>
     <dd>
+      Reference ranges generally differ between male and female so if we can't
+      determine the sex of the patient (e.g. it's coded as "U") then we can't
+      determine which reference range to apply.
     </dd>
 
     <dt>Insufficient data</dt>
     <dd>
+      Given the data we have we can't tell whether or not this result falls
+      within the reference range. For example, if the reference range is 10-20
+      and the result we have is "greater than 18" then we don't know whether
+      that result was within or over range.
     </dd>
 
     <dt>Underage for ref range</dt>
     <dd>
+      The only reference ranges we have are defined for adults. If the patient
+      is under 18 then we can't compare their result to a reference range.
     </dd>
   </dl>
 

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+<div class="row">
+
+  <h1>Frequently Asked Questions</h1>
+
+</div>
+
+<div class="row">
+
+  <h2 id="reference-ranges">What are reference ranges?</h2>
+  <p>
+  </p>
+
+
+  <h2 id="result-categories">What do the result categories and error codes mean?</h2>
+
+  <p>
+  </p>
+
+  <dl>
+    <dt>Within range / Under range / Over range</dt>
+    <dd>
+      We could determine the appropriate reference range for this result and have coded how the resut compared to this
+      reference range.
+    </dd>
+
+    <dt>No ref range</dt>
+    <dd>
+    </dd>
+
+    <dt>Invalid ref range</dt>
+    <dd>
+    </dd>
+
+    <dt>Non-numeric result</dt>
+    <dd>
+    </dd>
+
+    <dt>Unknown sex</dt>
+    <dd>
+    </dd>
+
+    <dt>Insufficient data</dt>
+    <dd>
+    </dd>
+
+    <dt>Underage for ref range</dt>
+    <dd>
+    </dd>
+  </dl>
+
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This adds a (stub) FAQ page and a link to the appropriate section of that page which appears when you select an option related to result categories in the form.

The suggested text for the FAQ is here (hopefully accessible to anyone within the DL) as I find PRs a poor mechanism for collaborating on text:
https://docs.google.com/document/d/105QPGrZOMs9FV_hBq1jldf0sKe6D0C9HRajSHbhAHNk/edit?usp=sharing