### PR TITLE
Use server-side pagination and sorting for data table

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -232,10 +232,9 @@ def layout(tests_df, ccgs_list):
                                         {"name": "numerator", "id": "numerator"},
                                         {"name": "denominator", "id": "denominator"},
                                     ],
-                                    filter_action="native",
-                                    sort_action="native",
+                                    sort_action="custom",
                                     sort_mode="multi",
-                                    page_action="native",
+                                    page_action="custom",
                                     page_current=0,
                                     page_size=50,
                                 )


### PR DESCRIPTION
This gives a huge performance improvement for large data tables. Note
that we remove the filtering option as it's a pain to implement and
possibly not that useful. See the "Backend Paging with Filtering"
section of: https://dash.plot.ly/datatable/callbacks

Closes #50