### PR TITLE
Add CSV download option to data table

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -65,3 +65,15 @@ body {
     display:block;
   }
 }
+
+#datatable-container {
+  margin-bottom: 2rem;
+}
+
+#datatable-container .dash-spreadsheet-container {
+  margin-bottom: 1rem;
+}
+
+#datatable-container .download-link-container {
+  text-align: right;
+}

--- a/layout.py
+++ b/layout.py
@@ -237,7 +237,18 @@ def layout(tests_df, ccgs_list):
                                     page_action="custom",
                                     page_current=0,
                                     page_size=50,
-                                )
+                                ),
+                                html.Div(
+                                    className="download-link-container",
+                                    children=[
+                                        html.A(
+                                            "Download as CSV",
+                                            id="datatable-download-link",
+                                            href="#",
+                                            className="btn btn-outline-primary",
+                                        )
+                                    ],
+                                ),
                             ],
                         )
                     ]


### PR DESCRIPTION
This is a little bit round the houses as it involves serializing the
relevant bits of the page state so that they can be passed to a Flask
view outside of the Dash application which can then generate the CSV.

There's some slight refactoring so that the code which generates the
data for the table can be used by both the DataTable view and the CSV
download endpoint.

Closes #51