### PR TITLE
Add note explaining error bars

### DIFF
--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -113,6 +113,7 @@ def update_deciles(page_state, click_data, current_qs):
     )
     traces = deciles_traces[:]
     months = deciles_traces[0].x
+    has_error_bars = False
     for colour, entity_id in zip(cycle(settings.LINE_COLOUR_CYCLE), entity_ids):
         entity_df = trace_df[trace_df[col_name] == entity_id]
         # First, plot the practice line
@@ -129,6 +130,7 @@ def update_deciles(page_state, click_data, current_qs):
             )
         )
         if entity_df["calc_value_error"].sum() > 0:
+            has_error_bars = True
             # If there's any error, bounds and fill
             traces.append(
                 go.Scatter(
@@ -195,6 +197,27 @@ def update_deciles(page_state, click_data, current_qs):
         title = f"Deciles for {fragment} over all {group_name}"
         title += "<br><sub>Select a row from the heatmap below to add lines to this chart</sub>"
 
+    annotations = []
+    if has_error_bars:
+        annotations.append(
+            go.layout.Annotation(
+                text=(
+                    "* coloured bands indicate uncertainty due to suppression of "
+                    'low numbers (<a href="/faq#low-numbers">see FAQ</a>)'
+                ),
+                font={"color": "#6c757d"},
+                xref="paper",
+                xanchor="right",
+                x=1,
+                xshift=120,
+                yref="paper",
+                yanchor="top",
+                y=0,
+                yshift=-26,
+                showarrow=False,
+            ),
+        )
+
     return {
         "data": traces,
         "layout": go.Layout(
@@ -203,5 +226,6 @@ def update_deciles(page_state, click_data, current_qs):
             xaxis={"range": [months[0], months[-1]]},
             showlegend=True,
             legend={"orientation": "v"},
+            annotations=annotations,
         ),
     }

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -76,6 +76,22 @@
     </dd>
   </dl>
 
+  <h2 id="low-numbers">What do the error bars mean?</h2>
+
+  <p>
+    To help mitigate potential privacy issues, we apply low number suppression
+    to our data. In practice this means that where we have a result count
+    between one and five we don't record the exact number and instead just
+    record the fact that the count lies in this range.
+  </p>
+
+  <p>
+    This means that many of our results come with an error range: we know that
+    the true value lies between X and Y but we can't say exactly where. In
+    charts we display this uncertainty using a coloured band around the line
+    where this indicates the minimum and maximum possible values.
+  </p>
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
The alignment here isn't perfect, but I think there's basically no way
to get this exactly right within Plotly. I did attempt doing this in
HTML and positioning it over the plot but then it wouldn't show up in
the PNG download and so I think this is overall better.

Closes #87