### PR TITLE
Move heatmap x-axis to the top

### DIFF
--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -215,7 +215,7 @@ def update_deciles(page_state, click_data, current_qs):
                 y=0,
                 yshift=-26,
                 showarrow=False,
-            ),
+            )
         )
 
     return {

--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -182,7 +182,7 @@ def update_heatmap(page_state, current_qs, current_fig):
             shapes=highlight_rectangles,
             title=title,
             height=height,
-            xaxis={"fixedrange": True},
+            xaxis={"fixedrange": True, "side": "top"},
             yaxis={
                 "fixedrange": True,
                 "automargin": True,


### PR DESCRIPTION
The bottom of the heatmap is often cut off so it makes more sense to
have it hear.

Closes #42