### PR TITLE
Hide deciles where we have too few entities

### DIFF
--- a/apps/base.py
+++ b/apps/base.py
@@ -90,6 +90,22 @@ def humanise_list(lst):
     return f"{head} and {tail}"
 
 
+def humanise_column_name(col_name, plural=True):
+    s = "s" if plural else ""
+    if col_name == "practice_id":
+        return f"practice{s}"
+    elif col_name == "ccg_id":
+        return f"CCG{s}"
+    elif col_name == "lab_id":
+        return f"lab{s}"
+    elif col_name == "test_code":
+        return f"test{s}"
+    elif col_name == "result_category":
+        return f"result type{s}"
+    else:
+        raise ValueError(col_name)
+
+
 def toggle_entity_id_list_from_click_data(click_data, entity_ids):
     entity_label = click_data["points"][0]["y"]
     # Hack: get the entity_id from the Y-axis label by working out the

--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -110,7 +110,6 @@ def update_deciles(page_state, click_data, current_qs):
         trace_df[trace_df[groupby].isin(highlight_entities)], col_name
     )
     traces = deciles_traces[:]
-    months = deciles_traces[0].x
     has_error_bars = False
     for colour, entity_id in zip(cycle(settings.LINE_COLOUR_CYCLE), entity_ids):
         entity_df = trace_df[trace_df[col_name] == entity_id]
@@ -216,12 +215,14 @@ def update_deciles(page_state, click_data, current_qs):
             )
         )
 
+    all_x_vals = set().union(*[trace.x for trace in traces])
+
     return {
         "data": traces,
         "layout": go.Layout(
             title=title,
             height=350,
-            xaxis={"range": [months[0], months[-1]]},
+            xaxis={"range": [min(all_x_vals), max(all_x_vals)]},
             showlegend=True,
             legend={"orientation": "v"},
             annotations=annotations,

--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -14,6 +14,7 @@ from apps.base import (
     get_title_fragment,
     humanise_list,
     humanise_result_filter,
+    humanise_column_name,
     initial_capital,
 )
 from apps.base import toggle_entity_id_list_from_click_data
@@ -160,49 +161,27 @@ def update_deciles(page_state, click_data, current_qs):
                 )
             )
 
-    if col_name == "practice_id":
-        group_name = "practices"
-    elif col_name == "ccg_id":
-        group_name = "CCGs"
-    elif col_name == "lab_id":
-        group_name = "labs"
-    elif col_name == "test_code":
-        group_name = "tests"
-    elif col_name == "result_category":
-        group_name = "result types"
-    else:
-        raise ValueError(col_name)
-
     fragment = get_title_fragment(numerators, denominators, result_filter)
 
     if show_deciles and entity_ids:
         fragment = initial_capital(fragment)
-        s = "s" if len(entity_ids) > 1 else ""
         if col_name == "test_code":
             title = get_title_fragment(entity_ids, denominators, result_filter)
-        elif col_name == "practice_id":
-            practice_list = humanise_list(entity_ids)
-            title = f"{fragment} at practice{s} {practice_list}"
-        elif col_name == "ccg_id":
-            ccg_list = humanise_list(entity_ids)
-            title = f"{fragment} at CCG{s} {ccg_list}"
-        elif col_name == "lab_id":
-            ccg_list = humanise_list(entity_ids)
-            title = f"{fragment} at lab{s} {ccg_list}"
         elif col_name == "result_category":
             category_list = humanise_list(
                 [humanise_result_filter(x) for x in entity_ids]
             )
             title = f"{fragment} {category_list}"
         else:
-            raise ValueError(col_name)
-        title += f"<br>(with deciles over all {group_name})"
+            entity_desc = humanise_column_name(col_name, plural=len(entity_ids) != 1)
+            title = f"{fragment} at {entity_desc} {humanise_list(entity_ids)}"
+        title += f"<br>(with deciles over all {humanise_column_name(col_name)})"
     elif show_deciles and not entity_ids:
-        title = f"Deciles for {fragment} over all {group_name}"
+        title = f"Deciles for {fragment} over all {humanise_column_name(col_name)}"
         title += "<br><sub>Select a row from the heatmap below to add lines to this chart</sub>"
     else:
         fragment = initial_capital(fragment)
-        title = f"{fragment} grouped by {group_name}"
+        title = f"{fragment} grouped by {humanise_column_name(col_name, plural=False)}"
 
     annotations = []
     if has_error_bars:

--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -182,6 +182,7 @@ def update_deciles(page_state, click_data, current_qs):
     else:
         fragment = initial_capital(fragment)
         title = f"{fragment} grouped by {humanise_column_name(col_name, plural=False)}"
+        title += "<br><sub>Click legend labels to hide/show lines — double-click to show just that line</sub>"
 
     annotations = []
     if has_error_bars:

--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -5,7 +5,7 @@ import plotly.graph_objs as go
 from dash.dependencies import Input, Output, State
 
 from app import app
-from apps.base import get_title_fragment, initial_capital
+from apps.base import get_title_fragment, initial_capital, humanise_column_name
 
 import numpy as np
 
@@ -120,22 +120,9 @@ def update_heatmap(page_state, current_qs, current_fig):
         "Target rowheight of {} for {} {}s".format(height, len(entities), groupby)
     )
 
-    if col_name == "practice_id":
-        group_name = "practice"
-    elif col_name == "ccg_id":
-        group_name = "CCG"
-    elif col_name == "lab_id":
-        group_name = "lab"
-    elif col_name == "test_code":
-        group_name = "test"
-    elif col_name == "result_category":
-        group_name = "result type"
-    else:
-        raise ValueError(col_name)
-
     fragment = get_title_fragment(numerators, denominators, result_filter)
     fragment = initial_capital(fragment)
-    title = f"{fragment} grouped by {group_name}"
+    title = f"{fragment} grouped by {humanise_column_name(col_name, plural=False)}"
 
     def make_highlight_rect(y_index):
         return {


### PR DESCRIPTION
Instead just show all the individual lines.

I went with 10 as the limit here on the basis that deciles don't make much sense in that case. There's a special case for result categories where we never show deciles, even if there end up being more than 10 of them because we decided that didn't make sense.

Closes #85 
