### PR TITLE
Result categories need to be ints

### DIFF
--- a/data.py
+++ b/data.py
@@ -18,7 +18,7 @@ def get_data(sample_size=None):
         "error": int,
         "lab_id": categorical,
         "practice_name": categorical,
-        "result_category": categorical,
+        "result_category": int,
         "test_code": categorical,
         "total_list_size": int,
     }


### PR DESCRIPTION
We want to do int-like things with them (e.g. filter where > 2) and even
straighforward equality comparison with ints fails if they are
categories. There is presumably little memory benefit in replacing ints
with categorical values in any case.