### PR TITLE
Work around routing bug which prevents form working

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
         <a class="nav-link" href="/">Home</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="/data">Analyse data</a>
+        <a class="nav-link" href="/data/">Analyse data</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="/measures">Measures</a>


### PR DESCRIPTION
If you visit `/data` rather than `/data/` then the Dash app loads but it
believes its hostname is `hostname` rather than `dash.openpathology.net`
so all requests it makes to the server fail.

The `hostname` string presumably comes from the end of `urls.py`:

    urls = url_map.bind(
        "hostname"
    )  # Required by werkzeug for redirects, although we never use