### PR TITLE
Show in/over/under range as a proportion of just numeric results

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -64,15 +64,15 @@ def layout(tests_df, ccgs_list, labs_list):
                     OPTION_SEPARATOR,
                     {
                         "value": "within_range",
-                        "label": "Proportion of results within reference range",
+                        "label": "Proportion of numeric results within reference range",
                     },
                     {
                         "value": "under_range",
-                        "label": "Proportion of results under reference range",
+                        "label": "Proportion of numeric results under reference range",
                     },
                     {
                         "value": "over_range",
-                        "label": "Proportion of results over reference range",
+                        "label": "Proportion of numeric results over reference range",
                     },
                     {
                         "value": settings.ERR_NO_REF_RANGE,

--- a/pipeline/get_data.py
+++ b/pipeline/get_data.py
@@ -28,11 +28,11 @@ def get_codes():
     dupe_codes = df.datalab_testcode[df.datalab_testcode.duplicated()]
     dupe_names = df.testname[df.testname.duplicated()]
     if not dupe_codes.empty or not dupe_names.empty:
-         raise ValueError(
-             f"Non-unique test codes or names\n"
-             f" codes: {', '.join(dupe_codes)}\n"
-             f" names: {', '.join(dupe_names)}"
-         )
+        raise ValueError(
+            f"Non-unique test codes or names\n"
+            f" codes: {', '.join(dupe_codes)}\n"
+            f" names: {', '.join(dupe_names)}"
+        )
     df.to_csv(target_path, index=False)
 
 


### PR DESCRIPTION
Previously we would show in-range results as a proportion of all test results which would mean that an increased proportion of error (or otherwise non-numeric) results would affect the output in an unintuitive way.

Closes #135 and (hopefully) closes #81 