### PR TITLE
Persist highlight_entities when changing groupby

### DIFF
--- a/stateful_routing.py
+++ b/stateful_routing.py
@@ -330,13 +330,7 @@ def update_highlight_entities_querystring(
     page_state = get_state(page_state)
     ctx = dash.callback_context
     triggered_inputs = [x["prop_id"].split(".")[0] for x in ctx.triggered]
-    if page_state["update_counter"] > 0 and "groupby-dropdown" in triggered_inputs:
-        # Remove any entity highlights if the groupby has changed (because
-        # they will no longer be pertinent).  However, only do this on
-        # updates subsequent to the first page load, because on the first
-        # page load we set the groupby from the URL.
-        qs = ""
-    elif "heatmap-graph" in triggered_inputs:
+    if "heatmap-graph" in triggered_inputs:
         # Update the URL to match the selected cell from the heatmap
         highlight_entities = query_string.get("highlight_entities", [])
         highlight_entities = toggle_entity_id_list_from_click_data(


### PR DESCRIPTION
This is an attempt to address #71. Storing the highlighted entities in
cookies feels like a bad move to me because I think it will lead to
unexpected edge cases (like things being inadvertantly hightlighted in
measure charts) which other users then can't reproduce.

It's true that the highlighted entities become no longer relevant when
changing the group by, but they won't do any harm either and they'll be
ready and waiting when you switch back to the original group by.

If we had more time we could refactor things so that the entity IDs in
the query string were prefix by their type. This would mean there
wouldn't be any possiblility of accidental matches. As it stands though,
the ID space of our types is almost entirely disjoint. (There's a bit of
overlap with some error codes and low pratice IDs, but this will
disappear if we stop annonymising practices.)

Closes #71