### PR TITLE
Fix list size issues with labs and CCGs

### DIFF
--- a/apps/deciles.py
+++ b/apps/deciles.py
@@ -104,7 +104,7 @@ def update_deciles(page_state, click_data, current_qs):
         hide_entities_with_sparse_data=page_state.get("sparse_data_toggle"),
     )
     if trace_df.empty:
-        return settings.EMPTY_RESPONSE
+        return EMPTY_RESPONSE
 
     # Don't show deciles in cases where they don't make sense
     if len(trace_df[col_name].unique()) < 10 or groupby == "result_category":

--- a/data.py
+++ b/data.py
@@ -33,6 +33,97 @@ def get_data(sample_size=None):
 
 
 @cache.memoize()
+def get_practice_data():
+    # NOTE: When we stop anonymising practice codes (or equally, if we use
+    # matching anonymised IDs in the practice_codes.csv file) we can replace
+    # the below with:
+    #
+    #   practice_df = read_practice_data()
+    #
+    # and remove the `synthesise_practice_data` function.
+    practice_df = synthesise_practice_data()
+    lab_df = get_labs_for_practices()
+    practice_df = practice_df.merge(lab_df, how="left", on=["month", "practice_id"])
+
+    return practice_df
+
+
+def synthesise_practice_data():
+    # Get a list size for each practice and month by extracting it from the
+    # main dataframe.  This means that if a practice requested no tests in a
+    # given month it won't show up in that month so its list size will be
+    # missing from the CCG total.
+    practice_df = get_data()[
+        ["month", "practice_id", "practice_name", "ccg_id", "total_list_size"]
+    ]
+    practice_df = practice_df.drop_duplicates(["month", "practice_id"])
+    # To work around the problem above we get the actual list size for each CCG
+    # from the practice_codes.csv file, calculate the difference, and insert
+    # dummy practice entries in each month to ensure that the CCG totals are
+    # correct.
+    true_ccg_df = read_practice_data().groupby(["month", "ccg_id"], observed=True).sum()
+    implied_ccg_df = practice_df.groupby(["month", "ccg_id"], observed=True).sum()
+    diff_df = true_ccg_df - implied_ccg_df
+    diff_df = diff_df[diff_df["total_list_size"] > 0]
+    diff_df = diff_df.reset_index()
+    practice_df = practice_df.append(diff_df, sort=True)
+    return practice_df
+
+
+def read_practice_data():
+    categorical = CategoricalDtype(ordered=False)
+    dtypes = {
+        "ccg_id": categorical,
+        "practice_id": categorical,
+        "practice_name": categorical,
+        # Even though list sizes are ints, because we have some NaN values in
+        # the data (i.e. practices without a known list size) we have to use
+        # floats
+        "total_list_size": float,
+    }
+    practice_df = pd.read_csv(
+        settings.CSV_DIR / "practice_codes.csv",
+        dtype=dtypes,
+        parse_dates=["month"],
+        # We need NaN handling (see above) but we don't want to interpret
+        # anything other than an empty string as NaN
+        keep_default_na=False,
+        na_values=[""],
+    )
+    practice_df = practice_df.dropna()
+    return practice_df
+
+
+def get_labs_for_practices():
+    """
+    Return a DataFrame mapping (month, practice_id) to a lab_id
+
+    This models the fiction that each practice "belongs" to a particular lab,
+    which we then use to provide a list size figure for labs to use as a
+    denominator. We assign each practice to the lab where it sent the majority
+    of its potassium tests, ignoring practices which sent less than 50
+    potassium tests to any one lab. This implies that some practices will not
+    have any associated lab in some months.
+    """
+    df = get_data()
+    # Filter to just Potassium tests and just the columns we need
+    df = df[df.loc[:, "test_code"] == "K"]
+    df = df[["month", "practice_id", "lab_id", "count"]]
+    # Get total tests each practice sent to each lab in each month
+    df = df.groupby(["month", "practice_id", "lab_id"], observed=True).sum()
+    df = df.reset_index()
+    # For each month and practice, keep only the lab with the highest test count
+    df = df.sort_values("count", na_position="first")
+    df = df.drop_duplicates(["month", "practice_id"], keep="last")
+    # Filter out practices which didn't order enough tests
+    df = df[df.loc[:, "count"] >= 50]
+    # We no longer need this column and don't want it accidentally ending up in
+    # any merges
+    df = df.drop(columns=["count"])
+    return df
+
+
+@cache.memoize()
 def get_count_data(
     numerators=[],
     denominators=[],
@@ -167,12 +258,7 @@ def get_count_data(
             filtered_df[cols_without_list_size].groupby(groupby, observed=True).sum()
         )
 
-        # First we construct a dataframe which contains practice details with
-        # exactly one entry for each practice-month pair.
-        practice_df = df[
-            ["month", "practice_id", "ccg_id", "lab_id", "total_list_size"]
-        ]
-        practice_df = practice_df.drop_duplicates(["month", "practice_id"])
+        practice_df = get_practice_data()
 
         # The easy case is when we're grouping by practice-related columns. In
         # this case we just apply the same group/sum to the practice dataframe

--- a/data.py
+++ b/data.py
@@ -104,9 +104,12 @@ def get_labs_for_practices():
     of its potassium tests, ignoring practices which sent less than 50
     potassium tests to any one lab. This implies that some practices will not
     have any associated lab in some months.
+
+    NOTE: If we change this algorithm we should also update the text at
+    /faq#lab-list-sizes
     """
     df = get_data()
-    # Filter to just Potassium tests and just the columns we need
+    # Filter to just potassium tests and just the columns we need
     df = df[df.loc[:, "test_code"] == "K"]
     df = df[["month", "practice_id", "lab_id", "count"]]
     # Get total tests each practice sent to each lab in each month

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -92,6 +92,19 @@
     where this indicates the minimum and maximum possible values.
   </p>
 
+  <h2 id="lab-list-sizes">How do you calculate patient list sizes for labs?</h2>
+
+  <p>
+    Unlike practices or CCGs, labs don't have a patient list and so, strictly
+    speaking, there's no such thing as a list size for a lab.  Nevertheless it
+    can be useful to have a rough estimate of how many patients are "served" by
+    a given lab to use as a denominator. We do this by assigning each practice
+    to its "primary" lab, which we define as the lab which processes the
+    majority of that practice's potassium tests, with a minimum threshold of 50
+    tests in order to filter out noise. A lab's list size is then calculated as
+    the sum of the list sizes of all the practices assigned to it.
+  </p>
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
This PR attempts to address the two issues raised in #140 which result
in odd list sizes when grouping by CCG or lab.


## CCGs

The CCG issue is caused by the fact that we were extracting list sizes
from our test count data which meant that where a practice ordered no
tests at all in a given month its list size would disappear from the CCG
total for that month. The solution is to get the list sizes directly
from the practice_codes file.

However we can't do this straightforwardly as things stand because the
practice code anonymisation means that we can't match up this file with
our test count data. So instead we calculate the correct total for each
CCG in each month and insert dummy entries into our list size dataframe
so that the totals come out correct when grouping by CCG. As noted in
the comments, once we stop anonymising we can just drop this code.


## Labs

The lab issue is that there is no straightforward definition of list
size for labs. The most naive option to say that a lab's list size is
the sum of the list sizes of all practices which ordered any tests from
it during the month. As noted, this causes lab list sizes to fluctuate
in a way which renders them not particularly useful as a denominator.

The solution we use in this PR is to assign each practice to the lab
where it sent the majority of its potassium tests, ignoring practices
which sent less than 50 potassium tests to any one lab. This implies
that some practices will not have any associated lab in some months, but
it at least keeps the lab list sizes reasonably stable.

Closes #140