### PR TITLE
Add dropdown to change heatmap ordering

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -81,3 +81,8 @@ body {
 #heatmap-click-hint p {
   margin-bottom: 0;
 }
+
+#sort-order-dropdown-container .form-group {
+  margin-bottom: 0;
+  margin-top: 1rem;
+}

--- a/layout.py
+++ b/layout.py
@@ -145,6 +145,9 @@ def layout(tests_df, ccgs_list, labs_list):
             )
         ]
     )
+    sort_order_form = dbc.FormGroup(
+        [dcc.Dropdown(id="sort-order-dropdown", clearable=False)]
+    )
     chart_selector_tabs = dbc.Tabs(
         id="chart-selector-tabs",
         active_tab="chart",
@@ -224,6 +227,15 @@ def layout(tests_df, ccgs_list, labs_list):
                                             id="heatmap-click-hint",
                                             className="alert alert-info text-center",
                                             style={"display": "none"},
+                                        ),
+                                        dbc.Row(
+                                            id="sort-order-dropdown-container",
+                                            children=[
+                                                dbc.Col(
+                                                    sort_order_form,
+                                                    width={"size": 6, "offset": 6},
+                                                )
+                                            ],
                                         ),
                                         html.Div(
                                             id="heatmap-container",


### PR DESCRIPTION
When displaying practice level data this adds the option to sort by CCG.
Otherwise it just uses the exsting sort, but with the option to switch
between ascending and descending. This at least has the advantage that
it hopefully makes the sorting more explicit.

As can be seen in the screenshot, this does add an extra bit of busyness to an already quite busy interface. But hopefully it's still worthwhile.
![localhost_8050_data_chart_by_practice_id_showing_ccg_id_all_lab_id_all_numerators_CREA_denominators_per1000_filter_all](https://user-images.githubusercontent.com/19630/71363716-f2126980-2591-11ea-936e-f527bae705c3.png)


Closes #47