### PR TITLE
Ignore non-numeric entity codes when converting to int

### DIFF
--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -145,7 +145,7 @@ def update_heatmap(page_state, current_qs, sort_order, current_fig):
     # Hack: result_category values are ints not strings, but everything gets
     # converted to strings when passed through the URL query params
     if col_name == "result_category":
-        highlight_entities = set(map(int, highlight_entities))
+        highlight_entities = set([int(s) for s in highlight_entities if s.isdigit()])
 
     highlight_rectangles = [
         make_highlight_rect(vals_by_entity.index.get_loc(x))


### PR DESCRIPTION
When dealing with `result_category` entities we need them to be ints
rather than strings. But we may have codes for entities of other types
in the highlight list which will blow up if we try to convert them to
ints, so we have to filter the list first.

Closes #144