### PR TITLE
Only include list sizes for practices with data

### DIFF
--- a/data.py
+++ b/data.py
@@ -35,6 +35,11 @@ def get_data(sample_size=None):
 @cache.memoize()
 def get_practice_data():
     practice_df = read_practice_data()
+    practices_with_data = get_data().practice_id.unique()
+    # If we have no data for a practice at all then we don't want to include it
+    # in our practice data, mainly so that its list size doesn't unfairly
+    # contribute to the CCG list size
+    practice_df = practice_df[practice_df.practice_id.isin(practices_with_data)]
     lab_df = get_labs_for_practices()
     practice_df = practice_df.merge(lab_df, how="left", on=["month", "practice_id"])
 

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -119,6 +119,17 @@
     the sum of the list sizes of all the practices assigned to it.
   </p>
 
+  <h2 id="ccg-list-sizes">Why is the patient list size for my CCG smaller than expected?</h2>
+
+  <p>
+    In some cases we have only partial data for a CCG because some practices
+    within it use a lab which doesn't (yet) supply us with data. Including
+    those practices within the total CCG list size would give a misleading
+    picture. For this reason when calculating the total CCG list size we only
+    include practices for which we have data (i.e. the practice code occurs at
+    least once somewhere in our data).
+  </p>
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
We now include practices if they occur at least once somewhere in our data. This gives us more stable list sizes than the older way of doing things (where we would change which practices were included based on their presence in our data on a month-by-month basis) while also being more representative than the previous method which would include practices for which we had no data at all (presumably because they sent their tests to a different lab).

Closes #150